### PR TITLE
Why have two places where we define users and groups?

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -59,12 +59,12 @@ Base = {
     "groups": [
         dict(name="cron", gid=16),
     ],
-    "users": [
+    'users': [
         dict(name="demouser",
-             password="password",
+             password="raspberrypi64",
              format="SHA512",
-             group="users",
-             groups="users,wheel,video,audio,adm,disk,lp,cdrom,usb,portage,cron".split(','),
+             group="100",
+             groups="users,wheel,video,audio,adm,disk,lp,cdrom,usb,portage,cron,plugdev,gpio,i2c,spi".split(','),
              shell="/bin/bash",
              uid="1000"
              )
@@ -157,16 +157,6 @@ GenPi64 = Base | {
     "stage3url": "http://distfiles.gentoo.org/releases/arm64/autobuilds/latest-stage3-arm64.txt",
     "stage3mirror": "http://distfiles.gentoo.org/releases/arm64/autobuilds/",
     "profile": "genpi64:default/linux/arm64/17.0/genpi64",
-    'users': [
-        dict(name="demouser",
-             password="raspberrypi64",
-             format="SHA512",
-             group="100",
-             groups="users,wheel,video,audio,adm,disk,lp,cdrom,usb,portage,cron,plugdev,gpio,i2c,spi".split(','),
-             shell="/bin/bash",
-             uid="1000"
-             )
-    ],
 
     'groups': [
         dict(name="i2c", gid=371),


### PR DESCRIPTION
Not sure that the Base config is the right place for this.