### PR TITLE
Set partition uuids explicitly in config

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -91,7 +91,7 @@ Base = {
 }
 
 GenPi64 = Base | {
-    "cmdline": 'console=serial0,115200 console=tty1 dwc_otg.lpm_enable=0 root=PARTUUID=%(UUID)s rootfstype=%(fstype)s fsck.repair=no usbhid.mousepoll=0 rootwait',
+    "cmdline": 'console=serial0,115200 console=tty1 dwc_otg.lpm_enable=0 root=PARTUUID=%(PARTUUID)s rootfstype=%(fstype)s fsck.repair=no usbhid.mousepoll=0 rootwait',
     "kernel": [
         "sys-firmware/raspberrypi-wifi-ucode",
         "sys-kernel/raspberrypi-kernel",
@@ -178,6 +178,9 @@ GenPi64 = Base | {
         'uuid': UUID[:8],
         'partitions': [
             {
+                'name': 'bootfs',
+                'partuuid': UUID[:8]+'-01',
+                'start': '1MiB',
                 'end': '256MiB',
                 'format': 'vfat',
                 'mount-point': '/boot',
@@ -187,6 +190,9 @@ GenPi64 = Base | {
                 }
             },
             {
+                'name': 'rootfs',
+                'partuuid': UUID[:8]+'-02',
+                'start': '256MiB',
                 'end': '100%',
                 'format': 'btrfs',
                 'mount-point': '/',

--- a/parsers/buildimage/buildimage
+++ b/parsers/buildimage/buildimage
@@ -19,17 +19,16 @@ p.wait()
 LOOP = p.stdout.read().decode("charmap").split(": ", 1)[0]
 
 os.system(f"parted {LOOP} mklabel {image['format']}") and exit(1)
-start = '1MiB'
 for idx,partition in enumerate(image['partitions']):
+    start = partition['start']
     end = partition['end']
     os.system(f"parted {LOOP} mkpart primary {start} {end}") and exit(1)
     if flags := partition.get('flags'):
         for f,v in flags.items():
             os.system(f"parted {LOOP} set {idx+1} {f} {v}") and exit(1)
-    start = end
 
     os.system(f"partprobe {LOOP}") and exit(1)
-    
+
     os.system(f"mkfs.{partition['format']} {LOOP}p{idx+1} {partition.get('args', '')}") and exit(1)
 
 os.system('mkdir -p image')
@@ -50,10 +49,8 @@ with open("etc/sudoers", "r") as f:
     sudoers = f.read()
 with open("etc/sudoers", "w") as f:
     f.write(sudoers.replace("# %wheel ALL=(ALL) NOPASSWD: ALL", "%wheel ALL=(ALL) NOPASSWD: ALL"))
-    
+
 os.chdir('..')
-
-
 
 os.system("umount --recursive image") and exit(1)
 os.system(f"losetup -d {LOOP}") and exit(1)

--- a/parsers/cmdline/cmdline
+++ b/parsers/cmdline/cmdline
@@ -10,9 +10,7 @@ import config
 config = getattr(config, os.environ['PROJECT'])
 
 image = config['image']
-UUID = image['uuid']
 with open("image/boot/cmdline.txt", "w") as cmdline:
     p = image['mount-order'][0]
-    uuid = UUID+'-%02i'%(p+1)
-    e = dict(UUID=uuid, fstype=image['partitions'][p]['format'])
+    e = dict(PARTUUID=image['partitions'[p]['partuuid'], fstype=image['partitions'][p]['format'])
     cmdline.write(config['cmdline'] % e)

--- a/parsers/fstab/fstab
+++ b/parsers/fstab/fstab
@@ -10,13 +10,12 @@ import config
 config = getattr(config, os.environ['PROJECT'])
 
 image = config['image']
-UUID = image['uuid']
 
 with open("image/etc/fstab", "w") as fstab:
     for p in image['mount-order']:
-        uuid = UUID+'-%02i'%(p+1)
+        partuuid = image['partitions'[p]['partuuid']
         target = image['partitions'][p]['mount-point']
         fstype = image['partitions'][p]['format']
         options = image['partitions'][p]['mount-options']
         options = options.replace("zstd:15", "zstd")
-        fstab.write(f'PARTUUID="{uuid}"\t{target}\t{fstype}\t{options}\t0\t0\n')
+        fstab.write(f'PARTUUID="{partuuid}"\t{target}\t{fstype}\t{options}\t0\t0\n')


### PR DESCRIPTION
This change allows for the individual partitions to have their partuuids set explicitly in the configuration file.

It doesn't immediately fix anything, but it does get me closer to being able to setup gpt partition tables properly.