### PR TITLE
Set partition uuids explicitly in config

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -90,7 +90,7 @@ Base = {
 }
 
 GenPi64 = Base | {
-    "cmdline": 'console=serial0,115200 console=tty1 dwc_otg.lpm_enable=0 root=PARTUUID=%(UUID)s rootfstype=%(fstype)s fsck.repair=no usbhid.mousepoll=0 rootwait=10 init=/sbin/init',
+    "cmdline": 'console=serial0,115200 console=tty1 dwc_otg.lpm_enable=0 root=PARTUUID=%(PARTUUID)s rootfstype=%(fstype)s fsck.repair=no usbhid.mousepoll=0 rootwait=10 init=/sbin/init',
     "kernel": [
         "sys-firmware/raspberrypi-wifi-ucode",
         "sys-kernel/raspberrypi-kernel",
@@ -182,6 +182,9 @@ GenPi64 = Base | {
         'uuid': UUID[:8],
         'partitions': [
             {
+                'name': 'bootfs',
+                'partuuid': UUID[:8]+'-01',
+                'start': '1MiB',
                 'end': '256MiB',
                 'format': 'vfat',
                 'mount-point': '/boot',
@@ -191,6 +194,9 @@ GenPi64 = Base | {
                 }
             },
             {
+                'name': 'rootfs',
+                'partuuid': UUID[:8]+'-02',
+                'start': '256MiB',
                 'end': '100%',
                 'format': 'btrfs',
                 'mount-point': '/',

--- a/parsers/cmdline/cmdline
+++ b/parsers/cmdline/cmdline
@@ -10,9 +10,7 @@ import config
 config = getattr(config, os.environ['PROJECT'])
 
 image = config['image']
-UUID = image['uuid']
 with open("image/boot/cmdline.txt", "w") as cmdline:
     p = image['mount-order'][0]
-    uuid = UUID+'-%02i'%(p+1)
-    e = dict(UUID=uuid, fstype=image['partitions'][p]['format'])
+    e = dict(PARTUUID=image['partitions'[p]['partuuid'], fstype=image['partitions'][p]['format'])
     cmdline.write(config['cmdline'] % e)

--- a/parsers/fstab/fstab
+++ b/parsers/fstab/fstab
@@ -10,13 +10,12 @@ import config
 config = getattr(config, os.environ['PROJECT'])
 
 image = config['image']
-UUID = image['uuid']
 
 with open("image/etc/fstab", "w") as fstab:
     for p in image['mount-order']:
-        uuid = UUID+'-%02i'%(p+1)
+        partuuid = image['partitions'[p]['partuuid']
         target = image['partitions'][p]['mount-point']
         fstype = image['partitions'][p]['format']
         options = image['partitions'][p]['mount-options']
         options = options.replace("zstd:15", "zstd")
-        fstab.write(f'PARTUUID="{uuid}"\t{target}\t{fstype}\t{options}\t0\t0\n')
+        fstab.write(f'PARTUUID="{partuuid}"\t{target}\t{fstype}\t{options}\t0\t0\n')


### PR DESCRIPTION
A more limited change compared to https://github.com/GenPi64/Build.Dist/pull/102 -- this PR is included in #102 , but should be able to stand on it's own.

This is useful because it will allow for configs in config.py to manually specify the UUID for both the root, and the boot, partition.

GPT partitions can't be "short id -01" like in msdos. They have to be actual UUIDs, which we can't currently do.