### PR TITLE
Don't specify CC and CXX for GenPi64Systemd.

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -339,9 +339,6 @@ GenPi64Systemd = GenPi64 | {
     "portage": GenPi64["portage"] | {
         "make.conf": GenPi64["portage"]["make.conf"] | {
             "USE": GenPi64["portage"]["make.conf"]["USE"] + ["systemd", "-elogind"],
-            'CC':"aarch64-unknown-linux-gnu-gcc-10.2.0",
-            'CXX':"aarch64-unknown-linux-gnu-g++-10.2.0",
-
         }
     },
     "etc": GenPi64["etc"] | {


### PR DESCRIPTION
Inherit from GenPi64 without overriding.