### PR TITLE
Remove value from rootwait kernel parameter

### DIFF
--- a/config/config.py
+++ b/config/config.py
@@ -90,7 +90,7 @@ Base = {
 }
 
 GenPi64 = Base | {
-    "cmdline": 'console=serial0,115200 console=tty1 dwc_otg.lpm_enable=0 root=PARTUUID=%(UUID)s rootfstype=%(fstype)s fsck.repair=no usbhid.mousepoll=0 rootwait init=/sbin/init',
+    "cmdline": 'console=serial0,115200 console=tty1 dwc_otg.lpm_enable=0 root=PARTUUID=%(UUID)s rootfstype=%(fstype)s fsck.repair=no usbhid.mousepoll=0 rootdelay=10 init=/sbin/init',
     "kernel": [
         "sys-firmware/raspberrypi-wifi-ucode",
         "sys-kernel/raspberrypi-kernel",


### PR DESCRIPTION
Using a value on rootwait is not expected and causes the kernel to ignore the parameter. It should either be without a value or you should use `rootdelay=10`. The reason it works, is that you have an initramfs that will be loaded and take a second or two. But in case someone is switching to a custom kernel without initramfs, the kernel will fail.

https://www.kernel.org/doc/html/latest/admin-guide/kernel-parameters.html?highlight=rootwait 