### PR TITLE
Use systemd native features to auto expand the root filesystem

### DIFF
--- a/config/pyconfig/GenPi64Config.py
+++ b/config/pyconfig/GenPi64Config.py
@@ -120,7 +120,7 @@ GenPi64 = Base | {
               'end': '100%',
               'filesystem': 'btrfs',
               'mount-point': '/',
-              'mount-options': 'noatime,compress=zstd:15,ssd,discard',
+              'mount-options': 'noatime,compress=zstd:15,ssd,discard,x-systemd.growfs',
               'args': '--force'
             }
         ]

--- a/config/pyconfig/GenPi64GenericConfig.py
+++ b/config/pyconfig/GenPi64GenericConfig.py
@@ -73,7 +73,7 @@ GenPi64Generic = Base | {
               'end': '0',
               'filesystem': 'btrfs',
               'mount-point': '/',
-              'mount-options': 'noatime,compress=zstd:15,ssd,discard',
+              'mount-options': 'noatime,compress=zstd:15,ssd,discard,x-systemd.growfs',
               'args': '--force'
             }
         ]

--- a/config/pyconfig/GenPi64SystemdConfig.py
+++ b/config/pyconfig/GenPi64SystemdConfig.py
@@ -18,9 +18,11 @@ GenPi64Systemd = GenPi64 | {
     "etc": GenPi64["etc"] | {
         "systemd/": {
             "network/": {
-                i: "systemd/network/" + i for i in os.listdir(os.path.join(os.environ.get('CONFIG_DIR'),
-                                                                           'systemd/network'))
+                i: "systemd/network/" + i for i in os.listdir(os.path.join(os.environ.get('CONFIG_DIR'), 'systemd/network'))
             }
+        },
+        "repart.d/": {
+            i: "repart.d/" + i for i in os.listdir(os.path.join(os.environ.get('CONFIG_DIR'), 'repart.d'))
         }
     },
     "services": {

--- a/config/pyconfig/GentooAMD64Config.py
+++ b/config/pyconfig/GentooAMD64Config.py
@@ -129,7 +129,7 @@ GentooAMD64 = Base | {
               'end': '0',
               'filesystem': 'btrfs',
               'mount-point': '/',
-              'mount-options': 'noatime,compress=zstd:15,ssd,discard',
+              'mount-options': 'noatime,compress=zstd:15,ssd,discard,x-systemd.growfs',
               'args': '--force'
             }
         ]

--- a/config/repart.d/root.conf
+++ b/config/repart.d/root.conf
@@ -1,0 +1,2 @@
+[Partition]
+Type=root


### PR DESCRIPTION
For GPT partitioned disks, systemd natively supports growing the partition and filesystem for root.