### PR TITLE
Match default CFLAGS to what we have in the overlay.

### DIFF
--- a/config/pyconfig/GenPi64Config.py
+++ b/config/pyconfig/GenPi64Config.py
@@ -39,7 +39,7 @@ GenPi64 = Base | {
     ],
     "portage": Base["portage"] | {
         "make.conf": Base["portage"]["make.conf"] | {
-            "CFLAGS": "-mtune=cortex-a72 -march=armv8-a+crc -O2 -pipe",
+            "CFLAGS": "-mtune=cortex-a72 -march=armv8-a+crc -ftree-vectorize -O2 -pipe",
             'CC':"aarch64-unknown-linux-gnu-gcc-11.2.0",
             'CXX':"aarch64-unknown-linux-gnu-g++-11.2.0",
             'CHOST':"aarch64-unknown-linux-gnu",


### PR DESCRIPTION
See https://github.com/GenPi64/genpi64-overlay/blob/master/profiles/targets/genpi64/make.defaults