### PR TITLE
CI: Update the stage3 checker to not fail fast

### DIFF
--- a/.github/workflows/stage3check.yml
+++ b/.github/workflows/stage3check.yml
@@ -13,6 +13,7 @@ jobs:
     runs-on: ubuntu-latest
 
     strategy:
+      fail-fast: false
       matrix:
         arch: [arm64,amd64]
         init: [openrc,systemd]


### PR DESCRIPTION
It should check all of them and not fail immediately if one of them fails.