### PR TITLE
change white space to tabs

### DIFF
--- a/parsers/rawcommand/rawcommand
+++ b/parsers/rawcommand/rawcommand
@@ -12,10 +12,10 @@ function finish
 trap finish EXIT
 
 cat <<- EOF > "${PROJECT_DIR}/chroot/em-$$"
-        #!/usr/bin/env bash
-        set -evx
-        source /etc/profile
-        $@
+	#!/usr/bin/env bash
+	set -evx
+	source /etc/profile
+	$@
 EOF
 chmod +x "${PROJECT_DIR}/chroot/em-$$"
 


### PR DESCRIPTION
### Overview
Minor corrections to heredocment descriptions.

### Changes
[parsers/rawcommand/rawcommand](https://github.com/GenPi64/Build.Dist/blob/5f3eb191034c824034fcd24de85481bdc08fdfaf/parsers/rawcommand/rawcommand#L15)
Modify the above file to use tabs like the following file.
[parsers/emerge/emerge](https://github.com/GenPi64/Build.Dist/blob/5f3eb191034c824034fcd24de85481bdc08fdfaf/parsers/emerge/emerge#L26)

### My environment
- Raspberry Pi 4 Model B Rev 1.4 8GB
- GenPi64 OpenRC
- Target image PROJECT="GenPi64Systemd"

### Issues
Execution of rawcommand fails.

```
running jobs [(<Popen: returncode: None args: ['/net/10.10.254.10/homes/kaoru/workspace/git...>, 'locale')]
+ source /net/10.10.254.10/homes/kaoru/workspace/git/github.com/GenPi64/Build.Dist/scripts/functions.sh
+ echo 'Running eselect locale set en_US.utf8'
Running eselect locale set en_US.utf8
+ trap finish EXIT
+ cat
+ chmod +x /net/10.10.254.10/homes/kaoru/workspace/git/github.com/GenPi64/Build.Dist/build/GenPi64OpenRC/chroot/em-1876
+ /net/10.10.254.10/homes/kaoru/workspace/git/github.com/GenPi64/Build.Dist/scripts/chroot.py /em-1876
%p1%d`pychroot succeeded%p1%d`pychroot succeededTraceback (most recent call last):
  File "/usr/lib/python3.10/site-packages/pychroot/scripts/pychroot.py", line 130, in main
  File "/usr/lib/python3.10/subprocess.py", line 501, in run
  File "/usr/lib/python3.10/subprocess.py", line 969, in __init__
  File "/usr/lib/python3.10/subprocess.py", line 1845, in _execute_child
OSError: [Errno 8] Exec format error: '/em-1876'
+ finish
+ ret=1
+ rm -f /net/10.10.254.10/homes/kaoru/workspace/git/github.com/GenPi64/Build.Dist/build/GenPi64OpenRC/chroot/em-1876
+ exit 1
FATAL: JOB locale FAILED with exit code 1
FATAL: JOB gentoo-base FAILED with exit code 1

after PARSERS

run complete.
```

It is a postscript of the part that seems to be related to the output contents of build.sh.

```
{'name': 'locale', 'deps': ['etc'], 'parser': 'rawcommand', 'args': ['eselect locale set en_US.utf8']},
```

I researched the following.
parsers/rawcommand/rawcommand outputs a small script in the heredoc and passes it to chroot.py in the part below.

["${SCRIPTS}/chroot.py" /em-$$](https://github.com/GenPi64/Build.Dist/blob/5f3eb191034c824034fcd24de85481bdc08fdfaf/parsers/rawcommand/rawcommand#L22)
At this time, it printed the following error:

```
OSError: [Errno 8] Exec format error: '/em-1876'
```

It seems that the shebang at the beginning of the script is not working.

### Additional Information

When creating an image for the SD card,
There was another problem with the path of the qemu-arm command, but I'm considering it as a separate problem.