### PR TITLE
Resolve package issues that depend on the SCRIPTS environment variable.

### DIFF
--- a/parsers/emerge/emerge
+++ b/parsers/emerge/emerge
@@ -31,6 +31,7 @@ cat <<- EOF > "${PROJECT_DIR}/chroot/em-$$"
 	export MAKEOPTS="-j$(nproc) -l$(nproc)"
 	${USE}
 	${EXTRA_EMERGE_ENV}
+	unset SCRIPTS
 	emerge $1
 EOF
 


### PR DESCRIPTION
### Overview
net-misc/dhcpcd-9.5.1 fails to emerge at JOB emerge_new_profile.

### Changes
[parsers/emerge/emerge](https://github.com/GenPi64/Build.Dist/blob/559dd933b88a79d9bd5e1efa360b45c7a42ad31d/parsers/emerge/emerge#L34)

I want to unset $SCRIPTS just before an emerge done in a child process.

### My environment
- Raspberry Pi 4 Model B Rev 1.4 8GB
- GenPi64 OpenRC
- Target image PROJECT="GenPi64Systemd"

### Issues
Log of failed emerge of net-misc/dhcpcd-9.5.1 at JOB emerge_new_profile.

```
make[1]: *** No rule to make target '/net/10.10.254.10/homes/kaoru/workspace/git/github.com/tin-machine/Build.Dist/scripts', needed by 'all'.  Stop.
```

The logs before and after are shown below.

```
aarch64-unknown-linux-gnu-gcc -march=armv8-a+crc -mtune=cortex-a72 -ftree-vectorize -O2 -pipe -march=native -O2 -pipe -std=c99 -DHAVE_C
ONFIG_H -DNDEBUG -D_GNU_SOURCE -D_FILE_OFFSET_BITS=64 -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE -DINET -DARP -DARPING -DIPV4LL -DINET6 -DDHCP6 -DAUTH -DPLUGIN_DEV -I.. -I../src -I./crypt -c ../compat/rb.c -o ../compat/rb.o
make[1]: *** No rule to make target '/net/10.10.254.10/homes/kaoru/workspace/git/github.com/tin-machine/Build.Dist/scripts', needed by 'all'.  Stop.
make[1]: *** Waiting for unfinished jobs....
make[1]: Leaving directory '/var/tmp/portage/net-misc/dhcpcd-9.5.1/work/dhcpcd-9.5.1/src'
make: *** [Makefile:24: all] Error 2
 * ERROR: net-misc/dhcpcd-9.5.1::gentoo failed (compile phase):
 *   emake failed
 *
 * If you need support, post the output of `emerge --info '=net-misc/dhcpcd-9.5.1::gentoo'`,
 * the complete build log and the output of `emerge -pqv '=net-misc/dhcpcd-9.5.1::gentoo'`.
 * The complete build log is located at '/var/tmp/portage/net-misc/dhcpcd-9.5.1/temp/build.log.gz'.
 * The ebuild environment file is located at '/var/tmp/portage/net-misc/dhcpcd-9.5.1/temp/environment'.
 * Working directory: '/var/tmp/portage/net-misc/dhcpcd-9.5.1/work/dhcpcd-9.5.1'
 * S: '/var/tmp/portage/net-misc/dhcpcd-9.5.1/work/dhcpcd-9.5.1'

 * Messages for package net-misc/dhcpcd-9.5.1:

 * ERROR: net-misc/dhcpcd-9.5.1::gentoo failed (compile phase):
 *   emake failed
 *
 * If you need support, post the output of `emerge --info '=net-misc/dhcpcd-9.5.1::gentoo'`,
 * the complete build log and the output of `emerge -pqv '=net-misc/dhcpcd-9.5.1::gentoo'`.
 * The complete build log is located at '/var/tmp/portage/net-misc/dhcpcd-9.5.1/temp/build.log.gz'.
 * The ebuild environment file is located at '/var/tmp/portage/net-misc/dhcpcd-9.5.1/temp/environment'.
 * Working directory: '/var/tmp/portage/net-misc/dhcpcd-9.5.1/work/dhcpcd-9.5.1'
 * S: '/var/tmp/portage/net-misc/dhcpcd-9.5.1/work/dhcpcd-9.5.1'
 ```

[Checking the Makefile in net-misc/dhcpcd,  uses $SCRIPTS as the target for all.](https://github.com/NetworkConfiguration/dhcpcd/blob/df3e2a164203c976562ee11f71ec8fe6626507a1/src/Makefile#L48)

This seems to cause net-misc/dhcpcd-9.5.1 to refer to Build.Dist/scripts when building.
( It appears that you are trying to reference an area outside of the chroot.
 I would appreciate it if you could point out if this is a problem in my environment )

I thought there are two approaches to improve this problem.
1. prefix all $SCRIPTS in the GenPi64 side scripts
2. unset $SCRIPTS just before emerge.
Either approach seemed to work, but with approach 1
- There are a lot of things to fix.
- Prefixing the $SCRIPTS does not look beautiful.
- There is concern that some prefixes may have similar problems in the future.
I decided to go with 2 for this reason.

If there are any dangers I am unaware of, please reject.

### Additional Information

I have confirmed that unsetting in the child process does not affect the parent process as follows.

Parent script
```
#!/bin/bash

export MyVar="MyVar"
echo "Parent process: MyVar=$MyVar"
./child_script.sh
echo "Parent process: MyVar=$MyVar"
```

child script( child_script.sh )
```
#!/bin/bash

echo "Child process: MyVar=$MyVar"
unset MyVar
echo "Child process after unset: MyVar=$MyVar"
```
