### PR TITLE
Strp the pgp signature from the tail of the stage3 file listing file if it is present

### DIFF
--- a/parsers/downloadstage3/downloadstage3
+++ b/parsers/downloadstage3/downloadstage3
@@ -3,7 +3,7 @@ pushd ${BASEDIR}
 stage3=$(${PARSERS}/config/getconfig stage3)
 
 stage3_url=$(${PARSERS}/config/getconfig stage3url)
-stage3_image=$(wget "${stage3_url}" -O - | tail -n 1 | cut -f 1 -d ' ' )
+stage3_image=$(wget "${stage3_url}" -O - | sed '/^-----BEGIN PGP SIGNATURE-----$/,$d' | tail -n 1 | cut -f 1 -d ' ' )
 stage3_mirror=$(${PARSERS}/config/getconfig stage3mirror)
 stage3_digests=$(wget ${stage3_mirror}/${stage3_image}.DIGESTS -O -)
 


### PR DESCRIPTION
Mirrors have started having contents like:
```
'-----BEGIN PGP SIGNED MESSAGE-----
Hash: SHA256

# BLAKE2B HASH
c0f45af4a6a7388b02b901fdfb107e4b5e56a0e36077c0ea0f3d634e061ca7a9c2ed844ca869ae0dda8b64846f03d5106b3c2d23d8e3b0848876045b02c39ae3  stage3-arm64-openrc-20231008T231659Z.tar.xz
# SHA512 HASH
26c5ff1b07bc15bf42b14d451908c33b4a4fa0d56c52d965cf927be35cecfc7caea3716be340f7e686d56132562f58460a126799b07e99eb8bf085660c86840f  stage3-arm64-openrc-20231008T231659Z.tar.xz
# BLAKE2B HASH
b1b731676e01e5375a0f8b543994800806281fdfb686fb4755fa5554093c43eff049e174db4bdb5f08aeacb119f9f5be5231954812d4320809338b36c957682f  stage3-arm64-openrc-20231008T231659Z.tar.xz.CONTENTS.gz
# SHA512 HASH
14ab2dcd89531a3cd743c8e8cf5674940034b08cce7d0bd9ac86bad122c3ee0dd7ce783651333578467ff63307f2e7477e086c8abee81f9747d1d7453889bd44  stage3-arm64-openrc-20231008T231659Z.tar.xz.CONTENTS.gz
-----BEGIN PGP SIGNATURE-----

iQEzBAEBCAAdFiEEU05CCatJ7uHBnZYWLERpXbn2BD0FAmUjUNIACgkQLERpXbn2
BD0dnwf+NS28FtLmycLt498cDn4/UqyTI/+A0zPA6XpG8RFZ8Q72+yMZ/gozYY5x
mRHSu4+ZPeanWu8+HbjSnL+TAQdsiju0BW30PUykV196epqExeGsBUT8jzFQ13Uo
bd4NNTqBwYmb/qraKW7rYuqFWCWRGQndNAYvECN6xcsVAHQRizjW5QeQDA4LUm+q
xpdh1CBzwHI4DRMpo3AhDF7yzwRn3MmbQpOErSVz5vqJ9uCvGP7y297wbNNBsYfP
eHq4iMcr+8S5Tw3bYFG21opPtNR5H00SYFgl0HEap99voXP7frf3iesCJ2Sh5JcH
T65H/QHw3fPhHJ9zJiinKmcyxtizjQ==
=CWBi
-----END PGP SIGNATURE-----'
```

Need to strip out the trailing pgp signature for the rest of our trivial textfile parsing to work.